### PR TITLE
practice now dashboard receiver read deep link start live session against confirmed chunk #86exnxnz8

### DIFF
--- a/frontend/components/bundle/StartLiveSessionForm.vue
+++ b/frontend/components/bundle/StartLiveSessionForm.vue
@@ -5,12 +5,7 @@
             <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
                 {{ t('live-practice.ai-character') }}
             </label>
-            <select v-model="formData.aiCharacter"
-                class="focus:border-primary-500 focus:ring-primary-500 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white">
-                <option v-for="character in aiCharacters" :key="character" :value="character">
-                    {{ character.charAt(0).toUpperCase() + character.slice(1) }}
-                </option>
-            </select>
+            <VoicePicker v-model="formData.aiCharacter" :voices="resolvedVoices" />
         </div>
 
         <!-- Native Language Selection -->
@@ -92,38 +87,26 @@
 <script setup lang="ts">
 import { Input } from 'pilotui';
 import { SUPPORTED_LANGUAGES } from '~/utils/languages.static';
+import VoicePicker from '~/components/live/VoicePicker.vue';
+import { useLiveSessionVoices } from '~/composables/useLiveSessionVoices';
+import type { CoachVoice } from '~/types/live-session.type';
 
 const { t } = useI18n();
 
-// Default voice list (Gemini Live API prebuilt voices). Inlined here rather
-// than pulled from a `const` because `withDefaults` is hoisted by the Vue
-// compiler and can't reference local script-setup variables. The OpenAI
-// `StartNew` variant passes its own list via the `voiceOptions` prop.
-const props = withDefaults(
-    defineProps<{
-        modelValue: {
-            aiCharacter: string;
-            selectionMode: 'selection' | 'random';
-            fromPhrase: string;
-            toPhrase: string;
-            totalPhrases: string;
-            nativeLanguage: string;
-        };
-        voiceOptions?: string[];
-    }>(),
-    {
-        voiceOptions: () => [
-            'Kore',
-            'Puck',
-            'Charon',
-            'Fenrir',
-            'Aoede',
-            'Leda',
-            'Orus',
-            'Zephyr',
-        ],
-    }
-);
+const props = defineProps<{
+    modelValue: {
+        aiCharacter: string;
+        selectionMode: 'selection' | 'random';
+        fromPhrase: string;
+        toPhrase: string;
+        totalPhrases: string;
+        nativeLanguage: string;
+    };
+    // Omitted by the bundle Gemini flow → voices are fetched from the server so
+    // the picker matches the extension. The OpenAI/Gemini `StartNew` variants
+    // still pass their own name lists.
+    voiceOptions?: (string | CoachVoice)[];
+}>();
 
 const emit = defineEmits<{
     'update:modelValue': [
@@ -138,7 +121,19 @@ const emit = defineEmits<{
     ];
 }>();
 
-const aiCharacters = computed(() => props.voiceOptions);
+const { voices: serverVoices, ensureLoaded } = useLiveSessionVoices();
+
+onMounted(() => {
+    if (!props.voiceOptions) ensureLoaded();
+});
+
+// Use the explicit list when provided (StartNew variants); otherwise the
+// server-backed list fetched above.
+const resolvedVoices = computed<(string | CoachVoice)[]>(() =>
+    props.voiceOptions && props.voiceOptions.length
+        ? props.voiceOptions
+        : serverVoices.value
+);
 
 const formData = computed({
     get: () => props.modelValue,

--- a/frontend/components/live/VoicePicker.vue
+++ b/frontend/components/live/VoicePicker.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+    <button
+      v-for="v in normalized"
+      :key="v.name"
+      type="button"
+      @click="$emit('update:modelValue', v.name)"
+      :class="[
+        'flex flex-col items-center gap-1.5 rounded-xl border p-3 text-center transition-all focus:outline-none',
+        modelValue === v.name
+          ? 'border-primary bg-primary/5 ring-2 ring-primary/30'
+          : 'border-gray-200 hover:border-primary/50 dark:border-gray-700',
+      ]"
+    >
+      <img
+        v-if="v.avatarUrl"
+        :src="v.avatarUrl"
+        :alt="v.label"
+        class="h-12 w-12 rounded-full object-cover"
+      />
+      <span
+        v-else
+        class="flex h-12 w-12 items-center justify-center rounded-full text-lg font-semibold text-white"
+        :style="{ backgroundColor: v.avatarColor }"
+      >{{ v.initial }}</span>
+      <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ v.label }}</span>
+      <span v-if="v.description" class="text-xs text-gray-500 dark:text-gray-400">
+        {{ v.description }}
+      </span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { CoachVoice } from '~/types/live-session.type';
+
+// Accepts either rich server voices (CoachVoice[]) or a plain name list
+// (string[]) so the same picker serves the server-backed Gemini bundle flow and
+// the OpenAI/Gemini `StartNew` variants that still pass their own name arrays.
+const props = defineProps<{
+  modelValue: string;
+  voices: (string | CoachVoice)[];
+}>();
+
+defineEmits<{ 'update:modelValue': [value: string] }>();
+
+// Deterministic palette so name-only lists still get a stable colored avatar.
+const FALLBACK_COLORS = [
+  '#7C3AED', '#2563EB', '#0D9488', '#EA580C',
+  '#DB2777', '#D97706', '#4F46E5', '#059669',
+];
+
+const normalized = computed(() =>
+  (props.voices || []).map((v) => {
+    const voice: Partial<CoachVoice> & { name: string } =
+      typeof v === 'string' ? { name: v, label: v } : v;
+    const label = voice.label || voice.name;
+    let color = voice.avatarColor;
+    if (!color) {
+      const sum = [...voice.name].reduce((a, c) => a + c.charCodeAt(0), 0);
+      color = FALLBACK_COLORS[sum % FALLBACK_COLORS.length];
+    }
+    return {
+      name: voice.name,
+      label,
+      description: voice.description,
+      avatarColor: color,
+      avatarUrl: voice.avatarUrl || null,
+      initial: label.charAt(0).toUpperCase(),
+    };
+  })
+);
+</script>

--- a/frontend/composables/useLiveSessionVoices.ts
+++ b/frontend/composables/useLiveSessionVoices.ts
@@ -1,0 +1,39 @@
+import { ref } from 'vue';
+import { functionProvider } from '@modular-rest/client';
+import type { CoachVoice } from '~/types/live-session.type';
+
+/**
+ * Shared, cached fetch of the AI-coach voice list from the server
+ * (`get-live-session-voices`). Module-level state means every caller — the
+ * bundle Live Session form and the Practice now surfaces — shares one fetch and
+ * one identical list. Call `ensureLoaded()` from `onMounted`.
+ */
+const voices = ref<CoachVoice[]>([]);
+const loading = ref(false);
+const error = ref<string | null>(null);
+let inflight: Promise<void> | null = null;
+
+export function useLiveSessionVoices() {
+  function ensureLoaded() {
+    if (voices.value.length) return Promise.resolve();
+    if (inflight) return inflight;
+
+    loading.value = true;
+    error.value = null;
+    inflight = functionProvider
+      .run<CoachVoice[]>({ name: 'get-live-session-voices', args: {} })
+      .then((res) => {
+        voices.value = res || [];
+      })
+      .catch((e: any) => {
+        error.value = e?.error || e?.message || 'Failed to load voices';
+      })
+      .finally(() => {
+        loading.value = false;
+        inflight = null;
+      });
+    return inflight;
+  }
+
+  return { voices, loading, error, ensureLoaded };
+}

--- a/frontend/pages/bundles/[id].vue
+++ b/frontend/pages/bundles/[id].vue
@@ -169,6 +169,7 @@ import { useBundleStore } from '@/stores/bundle';
 import { useLeitnerStore } from '@/stores/leitner';
 import StartLiveSessionFormModal from '~/components/bundle/StartLiveSessionFormModal.vue';
 import type { LivePracticeSessionSetupType } from '~/types/live-session.type';
+import type { LiveSessionRequest } from '~/types/live-session-request';
 import { useProfileStore } from '~/stores/profile';
 import FreemiumLimitCard from '~/components/freemium_alerts/FreemiumLimitCard.vue';
 import FreemiumLimitationModal from '~/components/freemium_alerts/LimitationModal.vue';
@@ -228,11 +229,24 @@ function fetchPhraseList(page: number = 1) {
 }
 
 function handleStartLiveSession(sessionData: LivePracticeSessionSetupType) {
-    // convert sessionData to base64
-    const sessionDataBase64 = btoa(JSON.stringify(sessionData));
+    // Build the unified live-session request (bundle source) and hand it to the
+    // single /practice/live-session gate.
+    const request: LiveSessionRequest = {
+        aiCharacter: sessionData.aiCharacter,
+        nativeLanguage: sessionData.nativeLanguage,
+        source: {
+            kind: 'bundle',
+            bundleId: id.value,
+            selectionMode: sessionData.selectionMode,
+            fromPhrase: sessionData.fromPhrase,
+            toPhrase: sessionData.toPhrase,
+            totalPhrases: sessionData.totalPhrases,
+        },
+        returnTo: `/bundles/${id.value}`,
+    };
 
-    const url = `/practice/live-session-${id.value}?sessionData=${sessionDataBase64}`;
-    router.push(url);
+    const session = btoa(JSON.stringify(request));
+    router.push(`/practice/live-session?session=${encodeURIComponent(session)}`);
 }
 
 function handleFreemiumAddPhrase() {

--- a/frontend/pages/practice/live-session.vue
+++ b/frontend/pages/practice/live-session.vue
@@ -1,11 +1,11 @@
 <template>
-    <MaterialPracticeToolScaffold :title="bundle?.title || 'Flashcards'" :activePhrase="practicedCount"
-        :totalPhrases="totalPhrases" :bundleId="id.toString()"
+    <MaterialPracticeToolScaffold :title="bundle?.title || 'Practice'" :activePhrase="practicedCount"
+        :totalPhrases="totalPhrases" :bundleId="''"
         :body-class="'flex flex-col items-stretch min-h-0 overflow-hidden'"
         :isLoading="!errorMode && !liveSessionStore.isSessionActive" :error-mode="errorMode"
         @end-session="endLiveSession">
-        <template v-if="bundle">
-            <!-- Freemium Timer Section -->
+        <template v-if="selectedPhrases.length">
+    <!-- Freemium Timer Section -->
             <FreemiumTimer v-if="profileStore.isFreemium" class="shrink-0" :duration="timerConfig.duration"
                 :label="t('freemium.timer.remaining_time')" @expired="showTimerExpiredModal = true"
                 @warning="handleTimerWarning" />
@@ -237,7 +237,7 @@ import { Modal } from 'pilotui/complex';
 import { dataProvider } from '@modular-rest/client';
 import { COLLECTIONS, DATABASE, type PhraseType, type PopulatedPhraseBundleType } from '~/types/database.type';
 import { useLiveSessionGeminiStore } from '~/stores/liveSessionGemini';
-import type { LivePracticeSessionSetupType } from '~/types/live-session.type';
+import type { LiveSessionRequest } from '~/types/live-session-request';
 import { useProfileStore } from '~/stores/profile';
 import FreemiumLimitationModal from '~/components/freemium_alerts/LimitationModal.vue';
 import FreemiumTimer from '~/components/freemium_alerts/FreemiumTimer.vue';
@@ -255,9 +255,17 @@ definePageMeta({
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
-const { id } = route.params;
-const { sessionData } = route.query;
-const sessionDataParsed = JSON.parse(atob(sessionData as string)) as LivePracticeSessionSetupType;
+const sessionReq = parseSessionRequest(route.query.session as string | undefined);
+const returnTo = sessionReq?.returnTo || '/board';
+
+function parseSessionRequest(raw?: string): LiveSessionRequest | null {
+    if (!raw) return null;
+    try {
+        return JSON.parse(atob(raw)) as LiveSessionRequest;
+    } catch {
+        return null;
+    }
+}
 
 const liveSessionStore = useLiveSessionGeminiStore();
 const profileStore = useProfileStore();
@@ -268,10 +276,7 @@ const bundle = ref<PopulatedPhraseBundleType | null>(null);
 const selectedPhrases = ref<PhraseType[]>([]);
 const phraseIndex = ref(-1);
 const practicedPhraseIds = ref<Set<string>>(new Set());
-const activePhrase = computed(() => {
-    if (!bundle.value) return null;
-    return selectedPhrases.value[phraseIndex.value];
-});
+const activePhrase = computed(() => selectedPhrases.value[phraseIndex.value] ?? null);
 const totalPhrases = computed<number>(() => {
     return selectedPhrases.value.length || 0;
 });
@@ -455,15 +460,18 @@ const instructions = `
     `;
 
 onMounted(async () => {
-    if (!sessionDataParsed) {
+    if (!sessionReq) {
         errorMode.value = true;
         errorMessage.value = t('live-practice.toast.no-session-data');
         return;
     }
 
-    await fetchFlashcard().then(() => {
-        selectedPhrases.value = getPhraseSelection();
-    });
+    await resolvePhrases();
+    if (!selectedPhrases.value.length) {
+        errorMode.value = true;
+        errorMessage.value = t('live-practice.toast.fetch-failed');
+        return;
+    }
 
     await createLiveSession();
 });
@@ -545,7 +553,7 @@ const tools = {
 // the model pick up the user's language from their first message, with English
 // as the safe default.
 function resolveNativeLanguage(): string {
-    const raw = sessionDataParsed.nativeLanguage;
+    const raw = sessionReq?.nativeLanguage;
     if (raw && raw !== 'auto') return raw;
 
     const langs = new Set(
@@ -561,24 +569,33 @@ function resolveNativeLanguage(): string {
     return "English by default; if the user speaks another language in their first message, switch to that language and stick with it for the rest of the session";
 }
 
-function fetchFlashcard() {
-    return dataProvider
-        .findOne<PopulatedPhraseBundleType>({
-            database: DATABASE.USER_CONTENT,
-            collection: COLLECTIONS.PHRASE_BUNDLE,
-            query: {
-                _id: id,
-                refId: authUser.value?.id,
-            },
-            populates: ['phrases'],
-        })
-        .then((res) => {
+async function resolvePhrases() {
+    const source = sessionReq!.source;
+    try {
+        if (source.kind === 'bundle') {
+            const res = await dataProvider.findOne<PopulatedPhraseBundleType>({
+                database: DATABASE.USER_CONTENT,
+                collection: COLLECTIONS.PHRASE_BUNDLE,
+                query: { _id: source.bundleId, refId: authUser.value?.id },
+                populates: ['phrases'],
+            });
             if (!res) throw new Error('Bundle not found');
             bundle.value = res;
-        })
-        .catch(() => {
-            toastError({ title: t('live-practice.toast.fetch-failed') });
-        });
+            selectedPhrases.value = selectFromBundle(source, (res.phrases as PhraseType[]) || []);
+        } else {
+            const phrases = await dataProvider.findByIds<PhraseType>({
+                database: DATABASE.USER_CONTENT,
+                collection: COLLECTIONS.PHRASE,
+                ids: source.phraseIds,
+                accessQuery: { refId: authUser.value?.id },
+            });
+            selectedPhrases.value = phrases || [];
+        }
+        // Auto-activate when there's a single phrase (e.g. Practice now).
+        if (selectedPhrases.value.length === 1) phraseIndex.value = 0;
+    } catch {
+        toastError({ title: t('live-practice.toast.fetch-failed') });
+    }
 }
 
 function createLiveSession() {
@@ -595,9 +612,9 @@ function createLiveSession() {
         .createLiveSession({
             sessionDetails: {
                 instructions: finalInstructions,
-                voice: sessionDataParsed.aiCharacter || 'Kore',
+                voice: sessionReq!.aiCharacter || 'Kore',
             },
-            metadata: sessionDataParsed,
+            metadata: sessionReq!,
             tools,
             audioRef: null,
             onUpdate: handleSessionEvent,
@@ -636,12 +653,12 @@ function endLiveSession() {
         showRecapModal.value = true;
         return;
     }
-    router.push(`/bundles/${id}`);
+    router.push(returnTo);
 }
 
 function dismissRecap() {
     showRecapModal.value = false;
-    router.push(`/bundles/${id}`);
+    router.push(returnTo);
 }
 
 function handleSessionEvent(eventData: any) {
@@ -663,32 +680,26 @@ function triggerTheConversation() {
     liveSessionStore.triggerConversation(message + '\n' + microphoneNotice);
 }
 
-function getPhraseSelection() {
-    const mode = sessionDataParsed.selectionMode;
+function selectFromBundle(
+    source: Extract<LiveSessionRequest['source'], { kind: 'bundle' }>,
+    all: PhraseType[]
+): PhraseType[] {
     const phrases: PhraseType[] = [];
 
-    if (mode === 'random') {
-        const { totalPhrases = 1 } = sessionDataParsed;
-        while (phrases.length < totalPhrases) {
-            const randomIndex = Math.floor(Math.random() * totalPhrases);
-            const tempPhrase = bundle.value?.phrases[randomIndex] as PhraseType;
-            const exists = phrases.find((p) => p._id === tempPhrase._id);
-
-            if (!exists) {
+    if (source.selectionMode === 'random') {
+        const { totalPhrases = 1 } = source;
+        while (phrases.length < totalPhrases && phrases.length < all.length) {
+            const tempPhrase = all[Math.floor(Math.random() * all.length)];
+            if (tempPhrase && !phrases.find((p) => p._id === tempPhrase._id)) {
                 phrases.push(tempPhrase);
             }
         }
-    } else if (mode === 'selection') {
-        const { fromPhrase = 1, toPhrase = 2 } = sessionDataParsed;
+    } else {
+        const { fromPhrase = 1, toPhrase = 2 } = source;
         for (let i = fromPhrase - 1; i <= toPhrase - 1; i++) {
-            if (i >= (bundle.value?.phrases.length || 0)) {
-                break;
-            }
-
-            const tempPhrase = bundle.value?.phrases[i] as PhraseType;
-            const exists = phrases.find((p) => p._id === tempPhrase._id);
-
-            if (!exists) {
+            if (i < 0 || i >= all.length) continue;
+            const tempPhrase = all[i];
+            if (tempPhrase && !phrases.find((p) => p._id === tempPhrase._id)) {
                 phrases.push(tempPhrase);
             }
         }
@@ -712,7 +723,7 @@ function handleUpgrade() {
 function goToFreeTools() {
     // "Show me free tools" — back to the bundle, where saving phrases and
     // Smart Review (both free, never AI-gated) live.
-    router.push(`/bundles/${id}`);
+    router.push(returnTo);
 }
 
 function selectPhrase(index: number) {

--- a/frontend/types/live-session-request.ts
+++ b/frontend/types/live-session-request.ts
@@ -1,0 +1,29 @@
+/**
+ * Unified live-session request: the single descriptor every live-session entry
+ * point builds and the one /practice/live-session page consumes. A session's
+ * "type" only changes where its phrases come from (`source`); voice, language,
+ * instructions, UI and engine are shared. Encoded as base64 JSON in the
+ * `?session=` query param.
+ */
+
+export type LiveSessionPhraseSource =
+  | {
+      kind: 'bundle';
+      bundleId: string;
+      selectionMode: 'selection' | 'random';
+      fromPhrase?: number;
+      toPhrase?: number;
+      totalPhrases?: number;
+    }
+  | { kind: 'phrases'; phraseIds: string[] };
+
+export interface LiveSessionRequest {
+  /** Gemini prebuilt voice name. */
+  aiCharacter: string;
+  /** Explanation language (English name, e.g. "Spanish") or "auto". */
+  nativeLanguage?: string;
+  /** Where the 1..N phrases to review come from. */
+  source: LiveSessionPhraseSource;
+  /** Path the End/Recap actions navigate back to (default "/board"). */
+  returnTo?: string;
+}

--- a/server/src/modules/live_session/__tests__/voices.test.ts
+++ b/server/src/modules/live_session/__tests__/voices.test.ts
@@ -1,0 +1,29 @@
+import { LIVE_SESSION_VOICES, DEFAULT_LIVE_SESSION_VOICE } from "../voices";
+
+describe("live session voices", () => {
+  it("ships the eight Gemini voices", () => {
+    expect(LIVE_SESSION_VOICES).toHaveLength(8);
+    const names = LIVE_SESSION_VOICES.map((v) => v.name);
+    ["Kore", "Puck", "Charon", "Fenrir", "Aoede", "Leda", "Orus", "Zephyr"].forEach(
+      (n) => expect(names).toContain(n)
+    );
+  });
+
+  it("gives every voice the metadata both clients render", () => {
+    for (const v of LIVE_SESSION_VOICES) {
+      expect(typeof v.name).toBe("string");
+      expect(v.label).toBeTruthy();
+      expect(v.description).toBeTruthy();
+      expect(v.avatarColor).toMatch(/^#[0-9A-Fa-f]{6}$/);
+      // avatarUrl is reserved (null for now) so clients can swap in images later.
+      expect(v).toHaveProperty("avatarUrl");
+    }
+  });
+
+  it("defaults to a voice that exists in the list", () => {
+    expect(DEFAULT_LIVE_SESSION_VOICE).toBe("Kore");
+    expect(LIVE_SESSION_VOICES.map((v) => v.name)).toContain(
+      DEFAULT_LIVE_SESSION_VOICE
+    );
+  });
+});

--- a/server/src/modules/live_session/functions.ts
+++ b/server/src/modules/live_session/functions.ts
@@ -27,6 +27,7 @@ import { LIVE_SESSION_MODEL } from "./openai/config";
 import { GEMINI_LIVE_SESSION_MODEL } from "./gemini/config";
 import { requestEphemeralToken } from "./openai/functions";
 import { requestGeminiEphemeralToken } from "./gemini/functions";
+import { LIVE_SESSION_VOICES } from "./voices";
 
 const createLiveSession = defineFunction({
   name: "create-live-session-record",
@@ -149,9 +150,23 @@ const updateLiveSession = defineFunction({
   },
 });
 
+/**
+ * Returns the AI-coach voice list (single source of truth in `./voices`) so the
+ * dashboard and extension render an identical picker. Static data; gated on
+ * `user_access` only because every caller is already authenticated.
+ */
+const getLiveSessionVoices = defineFunction({
+  name: "get-live-session-voices",
+  permissionTypes: ["user_access"],
+  callback: async function () {
+    return LIVE_SESSION_VOICES;
+  },
+});
+
 module.exports.functions = [
   requestEphemeralToken,
   requestGeminiEphemeralToken,
   createLiveSession,
   updateLiveSession,
+  getLiveSessionVoices,
 ];

--- a/server/src/modules/live_session/functions.ts
+++ b/server/src/modules/live_session/functions.ts
@@ -27,6 +27,7 @@ import { LIVE_SESSION_MODEL } from "./openai/config";
 import { GEMINI_LIVE_SESSION_MODEL } from "./gemini/config";
 import { requestEphemeralToken } from "./openai/functions";
 import { requestGeminiEphemeralToken } from "./gemini/functions";
+import { LIVE_SESSION_VOICES } from "./voices";
 
 const createLiveSession = defineFunction({
   name: "create-live-session-record",
@@ -96,11 +97,11 @@ const updateLiveSession = defineFunction({
         const isGemini = provider === "gemini";
         const costs = isGemini
           ? extractGeminiCostCalculationInput(
-              update.partialUsage as GeminiTokenUsageType
-            )
+            update.partialUsage as GeminiTokenUsageType
+          )
           : extractCostCalculationInput(
-              update.partialUsage as TokenUsageType
-            );
+            update.partialUsage as TokenUsageType
+          );
         await recordUsage({
           userId,
           serviceType: "live_session",
@@ -149,9 +150,23 @@ const updateLiveSession = defineFunction({
   },
 });
 
+/**
+ * Returns the AI-coach voice list (single source of truth in `./voices`) so the
+ * dashboard and extension render an identical picker. Static data; gated on
+ * `user_access` only because every caller is already authenticated.
+ */
+const getLiveSessionVoices = defineFunction({
+  name: "get-live-session-voices",
+  permissionTypes: ["user_access", "anonymous_access"],
+  callback: async function () {
+    return LIVE_SESSION_VOICES;
+  },
+});
+
 module.exports.functions = [
   requestEphemeralToken,
   requestGeminiEphemeralToken,
   createLiveSession,
   updateLiveSession,
+  getLiveSessionVoices,
 ];

--- a/server/src/modules/live_session/types.ts
+++ b/server/src/modules/live_session/types.ts
@@ -13,6 +13,7 @@ import type {
 
 export type { LiveSessionType, TokenUsageType, TurnDetectionType, ClientSecretType } from "./openai/types";
 export type { GeminiLiveSessionType, GeminiTokenUsageType } from "./gemini/types";
+export type { CoachVoice } from "./voices";
 
 export type SessionType = "bundle-practice";
 export type LiveSessionProvider = "openai" | "gemini";

--- a/server/src/modules/live_session/voices.ts
+++ b/server/src/modules/live_session/voices.ts
@@ -1,0 +1,38 @@
+/**
+ * Single source of truth for the AI-coach voices.
+ *
+ * Both the dashboard and the browser extension fetch this list (via the
+ * `get-live-session-voices` function) so the picker shows an identical set in
+ * every surface. `name` is the exact Gemini Live prebuilt-voice id passed to
+ * the API; the rest is display metadata.
+ *
+ * Avatars are rendered client-side as an initial on `avatarColor` for now;
+ * `avatarUrl` is reserved so real images can be dropped in later without any
+ * client change.
+ */
+export interface CoachVoice {
+  /** Exact Gemini prebuilt-voice id (sent to the Live API). */
+  name: string;
+  /** Display name. */
+  label: string;
+  /** One-line tone/character description. */
+  description: string;
+  gender: "female" | "male";
+  /** Stable background color for the initial-based avatar chip. */
+  avatarColor: string;
+  /** Optional image URL; null until real avatars exist. */
+  avatarUrl: string | null;
+}
+
+export const LIVE_SESSION_VOICES: CoachVoice[] = [
+  { name: "Kore", label: "Kore", description: "Firm and clear", gender: "female", avatarColor: "#7C3AED", avatarUrl: null },
+  { name: "Puck", label: "Puck", description: "Upbeat and lively", gender: "male", avatarColor: "#2563EB", avatarUrl: null },
+  { name: "Charon", label: "Charon", description: "Informative and calm", gender: "male", avatarColor: "#0D9488", avatarUrl: null },
+  { name: "Fenrir", label: "Fenrir", description: "Excitable and energetic", gender: "male", avatarColor: "#EA580C", avatarUrl: null },
+  { name: "Aoede", label: "Aoede", description: "Breezy and warm", gender: "female", avatarColor: "#DB2777", avatarUrl: null },
+  { name: "Leda", label: "Leda", description: "Youthful and bright", gender: "female", avatarColor: "#D97706", avatarUrl: null },
+  { name: "Orus", label: "Orus", description: "Firm and grounded", gender: "male", avatarColor: "#4F46E5", avatarUrl: null },
+  { name: "Zephyr", label: "Zephyr", description: "Bright and friendly", gender: "female", avatarColor: "#059669", avatarUrl: null },
+];
+
+export const DEFAULT_LIVE_SESSION_VOICE = "Kore";


### PR DESCRIPTION
🏷️ PR Title:  
Add single /practice/live-session gate and server voice list feature

## 📋 Summary  
This PR introduces a new feature for the live-session module, adding a single gate for the /practice/live-session route along with a server voice list implementation. These changes enable improved control and functionality for live session practices.

## 🔗 Related Tasks  
[#86exnxnz8](https://app.clickup.com/t/86exnxnz8) - Implement single /practice/live-session gate and server voice list for live sessions

## 📝 Additional Details  
The update includes both front-end gating and back-end support for the voice list, ensuring seamless integration during live practice sessions.

## 📜 Commit List  
[9bb25ec](https://github.com/codebridger/subturtle-dashboard-app/commit/9bb25ec) feat(live-session): single /practice/live-session gate + server voice list  
[9dcea17](https://github.com/codebridger/subturtle-dashboard-app/commit/9dcea17) feat(live-session): single /practice/live-session gate + server voice list