### PR TITLE
fix: suppress the global tier-limit modal when a page renders the loc…

### DIFF
--- a/frontend/composables/useTierLimitModal.ts
+++ b/frontend/composables/useTierLimitModal.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue';
+import { ref, onUnmounted } from 'vue';
 
 /**
  * Global "you hit a plan limit" modal state.
@@ -12,8 +12,17 @@ import { ref } from 'vue';
 const open = ref(false);
 const feature = ref('');
 
+// Features whose lock is rendered INLINE as a FeatureLocked card on their own
+// page (session_history on /sessions, weekly_insights on /statistic). While such
+// a page is mounted it owns the upsell, so the global modal defers — otherwise
+// the page-load probe that returns the lock stacks the modal on top of the card.
+const inlineLockedFeatures = new Set<string>();
+
 /** Open the global limit modal, tagged with the gated feature (tailors the copy). */
 export function openTierLimitModal(featureName = '') {
+    // Defer to an inline FeatureLocked card if the active page renders one for
+    // this feature — no double upsell (modal + card).
+    if (featureName && inlineLockedFeatures.has(featureName)) return;
     feature.value = featureName;
     open.value = true;
 }
@@ -22,6 +31,20 @@ export function openTierLimitModal(featureName = '') {
 export function closeTierLimitModal() {
     open.value = false;
     feature.value = '';
+}
+
+/**
+ * Declare that the current page renders `featureKey`'s lock inline (a
+ * FeatureLocked card), so the global tier-limit modal suppresses itself for that
+ * feature while the page is mounted. Call once in setup — registering there (not
+ * onMounted) guarantees it lands before the page's gated RPC resolves, so the
+ * modal never flashes. Auto-cleans on unmount.
+ */
+export function useInlineFeatureLock(featureKey: string) {
+    if (featureKey) inlineLockedFeatures.add(featureKey);
+    onUnmounted(() => {
+        if (featureKey) inlineLockedFeatures.delete(featureKey);
+    });
 }
 
 export function useTierLimitModal() {

--- a/frontend/pages/sessions/index.vue
+++ b/frontend/pages/sessions/index.vue
@@ -127,6 +127,7 @@ import { Icon, Button } from 'pilotui/elements';
 import { Pagination } from 'pilotui/complex';
 import PageHeader from '~/components/common/PageHeader.vue';
 import FeatureLocked from '~/components/FeatureLocked.vue';
+import { useInlineFeatureLock } from '~/composables/useTierLimitModal';
 import { functionProvider } from '@modular-rest/client';
 import type { LiveSessionRecordType, LivePracticeSessionSetupType } from '~/types/live-session.type';
 import { formatSessionDuration } from '~/utils/duration';
@@ -146,6 +147,10 @@ const currentPage = ref(1);
 const totalPages = ref(1);
 const isLoading = ref(false);
 const locked = ref(false);
+
+// session_history renders as an inline FeatureLocked card on this page, so the
+// global tier-limit modal defers to it (no double upsell on the same lock).
+useInlineFeatureLock('session_history');
 
 const isEmptyState = computed(() => !sessionList.value.length && !isLoading.value && !locked.value);
 

--- a/frontend/pages/statistic.vue
+++ b/frontend/pages/statistic.vue
@@ -61,6 +61,7 @@
     import PageHeader from '~/components/common/PageHeader.vue';
     import InstallExtensionBanner from '~/components/extension_nudge/InstallExtensionBanner.vue';
     import FeatureLocked from '~/components/FeatureLocked.vue';
+    import { useInlineFeatureLock } from '~/composables/useTierLimitModal';
 
     const { t } = useI18n();
 
@@ -80,6 +81,10 @@
     // weekly_insights gate: flipped when getUserStatistic returns 400 (TIER_LIMIT_REACHED),
     // i.e. the user's tier doesn't include insights — show the shared locked panel.
     const locked = ref(false);
+
+    // weekly_insights renders as an inline FeatureLocked card here, so the global
+    // tier-limit modal defers to it (no double upsell on the same lock).
+    useInlineFeatureLock('weekly_insights');
 
     function getRecentBundles() {
         dataProvider

--- a/frontend/tests/e2e/specs/subscription-ui.spec.ts
+++ b/frontend/tests/e2e/specs/subscription-ui.spec.ts
@@ -231,27 +231,25 @@ test.describe('Subscription UI — free/Starter surfaces (§7)', () => {
     // children are position:fixed), so it reads as "hidden". Assert visibility on the
     // panel CONTENT scoped within the dialog instead — which also excludes the
     // sessions page's in-page lock panel that repeats the same feature copy.
-    test('/statistic shows the weekly_insights lock panel + global upgrade modal', async ({ page }) => {
+    test('/statistic shows the weekly_insights lock panel, and the global modal defers to it', async ({ page }) => {
         await page.goto('/#/statistic');
 
         // Shared in-page FeatureLocked panel (S15) — replaces the empty-charts pattern.
         await expect(page.getByText('Weekly progress insights is part of Learner.')).toBeVisible();
 
-        // Global upgrade modal still fires from the 400 interceptor.
-        const dialog = page.getByRole('dialog');
-        await expect(dialog.getByText('Upgrade to unlock')).toBeVisible();
-        await expect(dialog.getByText('Progress insights are a Learner feature.')).toBeVisible();
+        // The page owns the upsell inline (useInlineFeatureLock), so the global
+        // tier-limit modal suppresses itself — no double surfacing of the same lock.
+        await expect(page.getByText('Upgrade to unlock')).not.toBeVisible();
     });
 
-    test('/sessions shows the session_history lock panel + global upgrade modal', async ({ page }) => {
+    test('/sessions shows the session_history lock panel, and the global modal defers to it', async ({ page }) => {
         await page.goto('/#/sessions');
 
         // Shared in-page FeatureLocked panel (S15) — replaces the old bespoke /sessions panel.
         await expect(page.getByText('Session history is part of Learner.')).toBeVisible();
 
-        const dialog = page.getByRole('dialog');
-        await expect(dialog.getByText('Upgrade to unlock')).toBeVisible();
-        await expect(dialog.getByText('Full session history is a Learner feature.')).toBeVisible();
+        // The page owns the upsell inline, so the global tier-limit modal defers.
+        await expect(page.getByText('Upgrade to unlock')).not.toBeVisible();
     });
 
     test('/settings/subscription renders four plan cards with GBP base prices', async ({ page }) => {


### PR DESCRIPTION
## 📋 Summary
This PR fixes the issue where the global tier-limit modal was incorrectly shown when a page renders an inline lock. The modal is now properly suppressed in this scenario.

## 🔗 Related Tasks
[#ca443e2](https://app.clickup.com/t/ca443e2) - Suppress the global tier-limit modal when a page renders the lock inline

## 📝 Additional Details
The change ensures a smoother user experience by preventing the modal from appearing unnecessarily during inline lock rendering on pages.

## 📜 Commit List
[ca443e2](https://app.github.com/commit/ca443e2) fix: suppress the global tier-limit modal when a page renders the lock inline