### PR TITLE
fix(translation): retry + validate structured LLM output to cut error rate

### DIFF
--- a/server/src/utils/__tests__/openrouter.test.ts
+++ b/server/src/utils/__tests__/openrouter.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { z } from "zod";
+import { OpenRouterService } from "../openrouter";
+
+/**
+ * These tests cover the retry + Zod-validation fallback added to
+ * createStructuredOutputWithZod, which exists because free/flash models
+ * intermittently return truncated or schema-invalid JSON.
+ */
+describe("OpenRouterService.createStructuredOutputWithZod", () => {
+  const schema = z.object({
+    translation: z.string(),
+    confidence: z.number(),
+  });
+
+  let service: OpenRouterService;
+
+  beforeEach(() => {
+    service = new OpenRouterService({ apiKey: "test-key" });
+  });
+
+  // Build a fake OpenRouter response wrapping the given content string.
+  const reply = (content: string) => ({
+    id: "id",
+    choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  });
+
+  const baseArgs = {
+    options: {
+      models: ["test/model"],
+      messages: [{ role: "user" as const, content: "hi" }],
+      temperature: 0,
+    },
+    zodSchema: schema,
+    schemaName: "test",
+    strict: true,
+  };
+
+  it("returns validated data on the first valid response", async () => {
+    const spy = jest
+      .spyOn(service, "createChatCompletion")
+      .mockResolvedValue(reply(JSON.stringify({ translation: "hola", confidence: 0.9 })));
+
+    const result = await service.createStructuredOutputWithZod(baseArgs);
+
+    expect(result).toEqual({ translation: "hola", confidence: 0.9 });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries when the first response is malformed JSON, then succeeds", async () => {
+    const spy = jest
+      .spyOn(service, "createChatCompletion")
+      .mockResolvedValueOnce(reply('{"translation": "hola"')) // truncated JSON
+      .mockResolvedValueOnce(reply(JSON.stringify({ translation: "hola", confidence: 0.8 })));
+
+    const result = await service.createStructuredOutputWithZod(baseArgs);
+
+    expect(result).toEqual({ translation: "hola", confidence: 0.8 });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries when the response parses but fails schema validation", async () => {
+    const spy = jest
+      .spyOn(service, "createChatCompletion")
+      // valid JSON but missing the required `confidence` field
+      .mockResolvedValueOnce(reply(JSON.stringify({ translation: "hola" })))
+      .mockResolvedValueOnce(reply(JSON.stringify({ translation: "hola", confidence: 0.7 })));
+
+    const result = await service.createStructuredOutputWithZod(baseArgs);
+
+    expect(result).toEqual({ translation: "hola", confidence: 0.7 });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("raises the temperature on each retry so deterministic models resample", async () => {
+    const spy = jest
+      .spyOn(service, "createChatCompletion")
+      .mockResolvedValueOnce(reply("not json"))
+      .mockResolvedValueOnce(reply("still not json"))
+      .mockResolvedValueOnce(reply(JSON.stringify({ translation: "ok", confidence: 1 })));
+
+    await service.createStructuredOutputWithZod(baseArgs);
+
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect((spy.mock.calls[0][0] as any).temperature).toBe(0);
+    expect((spy.mock.calls[1][0] as any).temperature).toBeCloseTo(0.3);
+    expect((spy.mock.calls[2][0] as any).temperature).toBeCloseTo(0.6);
+  });
+
+  it("throws after exhausting all attempts", async () => {
+    const spy = jest
+      .spyOn(service, "createChatCompletion")
+      .mockResolvedValue(reply("never valid"));
+
+    await expect(
+      service.createStructuredOutputWithZod({ ...baseArgs, retries: 1 })
+    ).rejects.toThrow();
+    expect(spy).toHaveBeenCalledTimes(2); // 1 + 1 retry
+  });
+
+  it("does not retry when retries is 0", async () => {
+    const spy = jest
+      .spyOn(service, "createChatCompletion")
+      .mockResolvedValue(reply("bad"));
+
+    await expect(
+      service.createStructuredOutputWithZod({ ...baseArgs, retries: 0 })
+    ).rejects.toThrow();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/utils/openrouter.ts
+++ b/server/src/utils/openrouter.ts
@@ -202,10 +202,17 @@ export class OpenRouterService {
   }
 
   /**
-   * Create a chat completion with structured JSON output using a Zod schema
-   * This method takes a Zod schema, converts it to JSON schema, and validates the result
-   * @param options Base request options
-   * @param zodSchema Zod schema for the structured output
+   * Create a chat completion with structured JSON output using a Zod schema.
+   *
+   * This converts the Zod schema to a JSON schema for the request, then
+   * validates the model's reply against the same Zod schema. Free/flash models
+   * intermittently fail structured output (truncated or malformed JSON, missing
+   * fields), so on a parse/validation/transport failure we retry a few times
+   * before giving up — each retry nudges the temperature up so a deterministic
+   * model doesn't simply repeat the same broken completion.
+   *
+   * @param context.retries Extra attempts after the first (default 2 -> up to 3
+   *   total). Set to 0 to disable retrying.
    * @returns Promise with the validated structured response of type T
    */
   async createStructuredOutputWithZod<T>(context: {
@@ -213,23 +220,65 @@ export class OpenRouterService {
     zodSchema: z.ZodType<T>;
     schemaName: string;
     strict: boolean;
+    retries?: number;
   }): Promise<T> {
-    const { options, zodSchema, schemaName, strict } = context;
+    const { options, zodSchema, schemaName, strict, retries = 2 } = context;
     // Convert Zod schema to JSON schema
     const jsonSchema = zodToJsonSchema(zodSchema, {
       target: "openApi3",
       $refStrategy: "none",
     });
 
-    // Get raw result using standard method
-    const rawResult = await this.createStructuredOutput<unknown>(
-      options,
-      jsonSchema,
-      schemaName,
-      strict
-    );
+    const totalAttempts = Math.max(1, retries + 1);
+    let lastError: unknown;
 
-    return rawResult as T;
+    for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+      // On retries, raise the temperature a little so a temperature-0 model
+      // returns a fresh sample instead of repeating the same malformed JSON.
+      const attemptOptions =
+        attempt === 1
+          ? options
+          : {
+              ...options,
+              temperature: Math.min(
+                1,
+                (options.temperature ?? 0) + 0.3 * (attempt - 1)
+              ),
+            };
+
+      try {
+        // Get raw result using standard method
+        const rawResult = await this.createStructuredOutput<unknown>(
+          attemptOptions,
+          jsonSchema,
+          schemaName,
+          strict
+        );
+
+        // Validate against the Zod schema so malformed structured output is
+        // caught here (and retried) rather than slipping through to callers.
+        const parsed = zodSchema.safeParse(rawResult);
+        if (parsed.success) {
+          return parsed.data;
+        }
+
+        lastError = new Error(
+          `Structured output failed schema validation: ${parsed.error.message}`
+        );
+      } catch (error: unknown) {
+        lastError = error;
+      }
+
+      if (attempt < totalAttempts) {
+        const message =
+          lastError instanceof Error ? lastError.message : String(lastError);
+        console.warn(
+          `Structured output attempt ${attempt}/${totalAttempts} failed, retrying: ${message}`
+        );
+      }
+    }
+
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
   }
 
   /**


### PR DESCRIPTION
## 📋 Summary
This PR improves the handling of structured LLM outputs by adding retry logic and validation to reduce the error rate in translations.

## 🔗 Related Tasks
[#dd5019b](https://app.clickup.com/t/dd5019b) - Retry and validate structured LLM output to cut error rate in translation

## 📝 Additional Details
The changes focus on enhancing robustness in processing LLM-generated translations by implementing retries on failure and validating the output format before further use.

## 📜 Commit List
[dd5019b](https://app.clickup.com/commit/dd5019b) fix(translation): retry + validate structured LLM output to cut error rate