### PR TITLE
Fix chunks confusion on translation function #86exw91re

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,19 @@ Modules are discovered dynamically by the modular-rest framework. Entry point: [
 - **i18n**: strings in [frontend/locales/en.json](frontend/locales/en.json) — only English is wired up today.
 - **UI components**: prefer **pilotui** (in-house Vue 3 + Tailwind library) before hand-rolling. Components are organized by category path (`pilotui/elements`, `pilotui/form`, `pilotui/shell`, etc.), use the `CL` prefix (e.g. `<CLButton>`), and require wrapping the app in `AppRoot` for theming. Registered in [frontend/plugins/component-library.ts](frontend/plugins/component-library.ts). **LLM-friendly docs**: <https://codebridger.github.io/lib-vue-components/llm.md> — fetch when adding or editing UI to see component APIs.
 
+## Branching
+
+**Every task gets its own feature branch — never commit task work directly to `dev` or `main`.** Follow the ClickUp branch convention used across the repo:
+
+```
+CU-<taskId>_<Short-Task-Title-Dashed>_<Author-Name>
+```
+
+e.g. `CU-86ext1gpf_Make-subscription-tiers-Stripe-metadata-driven-adaptive-pricing-Council-004-rollout_Navid-Shad`. The `<taskId>` is the ClickUp custom id (the `CU-…` shown on the task), the title is the task name with spaces → dashes, and the author is the assignee.
+
+- Branch off the latest `dev`; open a **PR into `dev`**. `dev` reaches `main` via the long-running `dev → main` PR — so a task only needs the one PR into `dev`.
+- **Footgun:** if you create the branch with `git switch -c <branch> origin/dev`, Git sets its upstream to `origin/dev`, and a plain `git push` (or a Git-client "sync") then lands the commits **straight on `dev`** instead of a new remote branch. Create it without that tracking and publish it explicitly: `git switch -c <branch>` then `git push -u origin <branch>` (or `--no-track` when branching off `origin/dev`).
+
 ## Commits & versioning
 
 This repo uses **semantic versioning**, and commit titles follow **Conventional Commits** so the type prefix maps to the intended `vMAJOR.MINOR.PATCH` bump. Pick the type by the change's real impact, not by habit:

--- a/server/scripts/setup-stripe-pricing.ts
+++ b/server/scripts/setup-stripe-pricing.ts
@@ -143,11 +143,10 @@ const TIER_SPECS: TierSpec[] = [
     prices: { monthly: 449, annual: 4299 },
     tagline: "Read, save, and chat with AI about every phrase you meet.",
     featureLabels: [
+      "Everything in Starter",
       "Save as many phrases as you want",
       "60 text chats per month",
       "Unlimited translations",
-      "Unlimited Smart Review",
-      "Voice top-ups when you want them",
     ],
     aiBudgetLabel: "voice top-ups any time",
     highlight: false,
@@ -173,6 +172,7 @@ const TIER_SPECS: TierSpec[] = [
     featureLabels: [
       "Everything in Reader",
       "90 minutes of voice chat a month",
+      "Top up voice minutes any time",
       "Weekly progress insights",
       "Full session history",
     ],
@@ -359,10 +359,19 @@ async function upsertTierProduct(spec: TierSpec): Promise<Stripe.Product> {
   const existing = await listAll<Stripe.Product>((p) => stripe.products.list(p));
   const match = existing.find((p) => p.metadata?.tier_id === spec.tierId);
   if (match) {
+    // Stripe MERGES metadata on update — it never drops keys you omit. A key we
+    // stop emitting (e.g. feature_5 after a tier loses its 5th bullet) would
+    // linger on the product, and the lenient display parser renders EVERY
+    // feature_<n> it finds, so the removed bullet keeps showing. Clear every
+    // existing key to "" first (Stripe deletes empty-valued keys), then overlay
+    // the desired metadata, making this product's metadata authoritative.
+    const authoritative: Record<string, string | number | null> = {};
+    for (const key of Object.keys(match.metadata || {})) authoritative[key] = "";
+    Object.assign(authoritative, metadata);
     const updated = await stripe.products.update(match.id, {
       name: spec.name,
       active: true,
-      metadata,
+      metadata: authoritative,
     });
     console.log(`  reused product ${updated.id} (${spec.name})`);
     return updated;
@@ -570,8 +579,7 @@ async function printPlan(): Promise<void> {
   for (const spec of TIER_SPECS) {
     const match = allProducts.find((p) => p.metadata?.tier_id === spec.tierId);
     console.log(
-      `  ${match ? "reuse " : "CREATE"} product ${spec.name}${
-        match ? ` (${match.id})` : ""
+      `  ${match ? "reuse " : "CREATE"} product ${spec.name}${match ? ` (${match.id})` : ""
       }`
     );
     if (match) {
@@ -589,8 +597,7 @@ async function printPlan(): Promise<void> {
             pr.metadata?.cadence === cadence
         );
         console.log(
-          `      ${exact ? "reuse " : "CREATE"} ${cadence} GBP price${
-            exact ? ` (${exact.id})` : ""
+          `      ${exact ? "reuse " : "CREATE"} ${cadence} GBP price${exact ? ` (${exact.id})` : ""
           }`
         );
       }
@@ -606,8 +613,7 @@ async function printPlan(): Promise<void> {
         p.metadata?.kind === "voice_topup" && p.metadata?.pack_key === spec.key
     );
     console.log(
-      `  ${match ? "reuse " : "CREATE"} ${spec.name}${
-        match ? ` (${match.id})` : ""
+      `  ${match ? "reuse " : "CREATE"} ${spec.name}${match ? ` (${match.id})` : ""
       }`
     );
   }
@@ -642,8 +648,7 @@ async function printPlan(): Promise<void> {
     (c) => c.metadata?.managed_by === PORTAL_CONFIG_MARKER
   );
   console.log(
-    `  ${portalMatch ? "reuse " : "CREATE"} portal configuration${
-      portalMatch ? ` (${portalMatch.id})` : ""
+    `  ${portalMatch ? "reuse " : "CREATE"} portal configuration${portalMatch ? ` (${portalMatch.id})` : ""
     }`
   );
 }
@@ -665,8 +670,7 @@ async function main(): Promise<void> {
   }
 
   console.log(
-    `Stripe pricing setup (Council 004, GBP base) - ${mode} mode${
-      DRY_RUN ? " [DRY RUN]" : ""
+    `Stripe pricing setup (Council 004, GBP base) - ${mode} mode${DRY_RUN ? " [DRY RUN]" : ""
     }\n`
   );
 
@@ -740,22 +744,22 @@ async function main(): Promise<void> {
   console.log("\n\n=== Manual steps (NOT done by this script) ===\n");
   console.log(
     "  1. Adaptive Pricing — Dashboard -> Settings -> Payments -> Adaptive Pricing -> On.\n" +
-      "     Lets non-GBP customers see local currency at checkout while we settle in GBP."
+    "     Lets non-GBP customers see local currency at checkout while we settle in GBP."
   );
   console.log(
     "  2. Restrict who can edit product metadata — under ADR-004 a metadata edit GRANTS\n" +
-      "     MONEY (credits / voice minutes). Treat Stripe edit access as production access."
+    "     MONEY (credits / voice minutes). Treat Stripe edit access as production access."
   );
   if (portalConfigId) {
     console.log(
       "  3. Customer Portal — plan-switching configured automatically (id above). Revisit\n" +
-        "     only to change branding or the privacy / terms URLs."
+      "     only to change branding or the privacy / terms URLs."
     );
   } else {
     console.log(
       "  3. Customer Portal — NOT configured (step 5 failed above). Set STRIPE_PORTAL_PRIVACY_URL\n" +
-        "     + STRIPE_PORTAL_TOS_URL in server/.env and re-run, or enable subscription updates by\n" +
-        "     hand under Dashboard -> Settings -> Billing -> Customer portal."
+      "     + STRIPE_PORTAL_TOS_URL in server/.env and re-run, or enable subscription updates by\n" +
+      "     hand under Dashboard -> Settings -> Billing -> Customer portal."
     );
   }
 }

--- a/server/src/modules/translation/__tests__/chunk-filter.test.ts
+++ b/server/src/modules/translation/__tests__/chunk-filter.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "@jest/globals";
+import { filterChunksToSelection } from "../chunk-filter";
+
+describe("filterChunksToSelection", () => {
+  it("drops chunks taken from the context, keeping only those in the marked text", () => {
+    // The real-world failing case from the task: the marked text is
+    // "improvements are included", yet the model also returned "related to" and
+    // "based on", which appear only in the surrounding context.
+    const phrase = "improvements are included";
+    const chunks = [
+      { text: "improvements are included", type: "other" },
+      { text: "related to", type: "collocation" },
+      { text: "based on", type: "collocation" },
+    ];
+
+    expect(filterChunksToSelection(chunks, phrase)).toEqual([
+      { text: "improvements are included", type: "other" },
+    ]);
+  });
+
+  it("keeps a chunk that appears verbatim inside a longer selection", () => {
+    const phrase = "they finally decided to give up on the project";
+    const chunks = [
+      { text: "give up on", type: "phrasal_verb" },
+      { text: "in the end", type: "discourse_marker" }, // not in the selection
+    ];
+
+    expect(filterChunksToSelection(chunks, phrase)).toEqual([
+      { text: "give up on", type: "phrasal_verb" },
+    ]);
+  });
+
+  it("matches case- and whitespace-insensitively", () => {
+    const phrase = "In Fact, the\nresults were good";
+    const chunks = [
+      { text: "in fact" }, // different case
+      { text: "the   results" }, // collapsed whitespace vs newline
+    ];
+
+    expect(filterChunksToSelection(chunks, phrase)).toEqual([
+      { text: "in fact" },
+      { text: "the   results" },
+    ]);
+  });
+
+  it("drops chunks with empty or whitespace-only text", () => {
+    const phrase = "a perfectly normal sentence";
+    const chunks = [{ text: "" }, { text: "   " }, { text: "normal" }];
+
+    expect(filterChunksToSelection(chunks, phrase)).toEqual([
+      { text: "normal" },
+    ]);
+  });
+
+  it("returns an empty array when the selection is empty", () => {
+    expect(filterChunksToSelection([{ text: "anything" }], "")).toEqual([]);
+  });
+
+  it("returns an empty array for missing or non-array chunks", () => {
+    expect(filterChunksToSelection(undefined, "some phrase")).toEqual([]);
+    expect(filterChunksToSelection(null, "some phrase")).toEqual([]);
+  });
+});

--- a/server/src/modules/translation/chunk-filter.ts
+++ b/server/src/modules/translation/chunk-filter.ts
@@ -1,0 +1,41 @@
+/**
+ * Normalise text for a forgiving "does this appear in the selection?" check:
+ * lower-case, collapse any run of whitespace to a single space, and trim. This
+ * lets a chunk the model capitalised differently (or that spans a line break)
+ * still match, while still rejecting patterns that simply are not in the
+ * selection.
+ */
+function normaliseForMatch(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Keep only the chunks whose `text` actually appears inside the user's marked
+ * selection (`phrase`).
+ *
+ * The detailed-translation and advice models intermittently surface reusable
+ * patterns drawn from the surrounding `context` rather than the marked text
+ * itself — e.g. selecting "improvements are included" yet returning "related to"
+ * and "based on", which only exist in the context paragraph. Chunks must come
+ * from the marked text only, so this is the deterministic guardrail that
+ * enforces that contract regardless of what the model returns.
+ *
+ * Matching is whitespace- and case-insensitive but otherwise verbatim (no
+ * punctuation stripping), matching the "appears verbatim inside the selection"
+ * rule the prompts ask the model to follow.
+ */
+export function filterChunksToSelection<T extends { text: string }>(
+  chunks: T[] | undefined | null,
+  phrase: string
+): T[] {
+  if (!Array.isArray(chunks)) return [];
+
+  const selection = normaliseForMatch(typeof phrase === "string" ? phrase : "");
+  if (!selection) return [];
+
+  return chunks.filter((chunk) => {
+    const text =
+      typeof chunk?.text === "string" ? normaliseForMatch(chunk.text) : "";
+    return text.length > 0 && selection.includes(text);
+  });
+}

--- a/server/src/modules/translation/service.ts
+++ b/server/src/modules/translation/service.ts
@@ -9,6 +9,7 @@ import {
   LanguageLearningDataSchema,
   TranslationAdviceSchema,
 } from "./schema";
+import { filterChunksToSelection } from "./chunk-filter";
 import { TRANSLATION_MODELS } from "../../utils/openrouter-models";
 
 /**
@@ -81,8 +82,8 @@ export async function getDetailedTranslation({
 
   Phonetic transliteration: spell out how to pronounce the SOURCE-language "phrase" itself (${sourceLanguage} -> read by a ${targetLanguage} speaker), written using the ${targetLanguage} alphabet. Do NOT transliterate the translation. For long selections (~5 words or more), return an empty string for the top-level transliteration and rely on the per-chunk transliterations instead.
 
-  Chunks: inside the user's selection ("phrase"), find the reusable language patterns worth learning (collocations, phrasal verbs, idioms, discourse markers).
-  Rules: at most one chunk per 5-8 words of the selection, hard ceiling of 2 chunks. Each chunk's "text" must appear verbatim inside the selection. For each chunk, also provide: "transliteration" (how to pronounce that chunk, source language, in the ${targetLanguage} alphabet) and "definition" (a short, self-contained explanation of that chunk's meaning and usage, 1-2 sentences, in ${targetLanguage}).
+  Chunks: look ONLY inside the user's selection ("phrase") and find the reusable language patterns worth learning there (collocations, phrasal verbs, idioms, discourse markers). The "context" is provided ONLY to disambiguate the selection's meaning — NEVER take a chunk from the context. A pattern is a valid chunk only if its exact words appear inside the selection itself.
+  Rules: at most one chunk per 5-8 words of the selection, hard ceiling of 2 chunks. Each chunk's "text" must appear verbatim inside the selection (not merely inside the context). For each chunk, also provide: "transliteration" (how to pronounce that chunk, source language, in the ${targetLanguage} alphabet) and "definition" (a short, self-contained explanation of that chunk's meaning and usage, 1-2 sentences, in ${targetLanguage}).
   Return an empty "chunks" array when the selection is under ~5 words, or when the selection is written in a different language than the target learning language.`;
 
   const userPrompt = `
@@ -117,6 +118,11 @@ export async function getDetailedTranslation({
         strict: true,
       });
 
+    // Guardrail: the model occasionally pulls chunks from the surrounding
+    // context instead of the marked text. Chunks must come from the selection
+    // only, so drop any whose text does not appear inside the phrase.
+    result.chunks = filterChunksToSelection(result.chunks, phrase);
+
     // Result is already validated by Zod
     return result;
   } catch (error: unknown) {
@@ -149,7 +155,7 @@ export async function getTranslationAdvice({
 
   Your MAIN job is to answer the user's questions about this phrase: meaning, grammar, usage, nuance, examples, differences between words, etc. Put your answer in "reply".
 
-  Editing the highlighted patterns is a SECONDARY ability. Only return a "chunks" array when the user EXPLICITLY asks to add, remove, or change which patterns are highlighted (e.g. "highlight X", "remove that", "don't include Y"). When you do, each chunk's "text" must appear verbatim in the selection, include its "transliteration" (pronunciation in the ${targetLanguage} alphabet), and you may also add a short "reply" explaining the change.
+  Editing the highlighted patterns is a SECONDARY ability. Only return a "chunks" array when the user EXPLICITLY asks to add, remove, or change which patterns are highlighted (e.g. "highlight X", "remove that", "don't include Y"). When you do, each chunk's "text" must appear verbatim in the selection — NEVER take a chunk from the context — include its "transliteration" (pronunciation in the ${targetLanguage} alphabet), and you may also add a short "reply" explaining the change.
   If the user is just asking a question (even one that mentions a phrase, like "what about 'on the'?"), answer it in "reply" and DO NOT change the chunks.`;
 
   // Maintain the conversation: replay prior turns so the model has context.
@@ -179,6 +185,12 @@ export async function getTranslationAdvice({
         schemaName: "translation_advice",
         strict: true,
       });
+
+    // Same guardrail as the save flow: any chunks the advisor proposes must
+    // come from the marked text, not the surrounding context.
+    if (result.chunks) {
+      result.chunks = filterChunksToSelection(result.chunks, phrase);
+    }
 
     return result;
   } catch (error: unknown) {


### PR DESCRIPTION
## 📋 Summary
This PR includes a fix to the subscription logic by rewriting Stripe product metadata authoritatively in the setup-stripe-pricing process. It also resolves an issue in the translation functionality by extracting chunks only from the specifically marked text rather than its surrounding context. Additionally, documentation has been enhanced with the addition of ClickUp-based branching and pull request guidelines in the CLAUDE.md file.

## 🔗 Related Tasks
[#86exw91re](https://app.clickup.com/t/86exw91re) - Fix chunks confusion on translation function (Navid Shad)

## 📝 Additional Details
- The Stripe metadata fix ensures that product metadata is correctly set up and authoritative during pricing setup.
- The translation fix improves text chunk extraction accuracy to avoid including extraneous context.
- Documentation updates provide clearer branching and PR guidelines based on ClickUp workflows.

## 📜 Commit List
- [260be05](commit-url) fix(subscription): rewrite Stripe product metadata authoritatively in setup-stripe-pricing  
- [f408e83](commit-url) fix(translation): only extract chunks from the marked text, not its context  
- [3b06ff4](commit-url) docs: add ClickUp-based branching and pull request guidelines to CLAUDE.md