### PR TITLE
docs: add sibling repos (extension, pilotui) and cross-repo testing workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,23 @@ SubTurtle Dashboard App — a language-learning dashboard for SubTurtle (learn-b
 | Production | <https://dashboard.subturtle.app> |
 | Development | <https://dev.dashboard.subturtle.app> |
 
+## Sibling repositories
+
+SubTurtle spans several repos. Two siblings interact directly with this dashboard and often have to be touched to develop or test a dashboard change end to end:
+
+| Repo | Purpose | GitHub | Typical local path |
+| --- | --- | --- | --- |
+| **subturtle-extension-apps** | Browser extension — the learn-by-subtitle capture surface. Talks to the same `@modular-rest` backend protocol, and enforces the identical Conventional-Commits → semver mapping (via `semantic-release`). | <https://github.com/codebridger/subturtle-extension-apps> | `../subturtle-extension-apps` |
+| **pilotui** | In-house Vue 3 + Tailwind component library — the `pilotui` npm dependency the frontend consumes (`CL`-prefixed components). LLM docs: <https://codebridger.github.io/lib-vue-components/llm.md> | <https://github.com/codebridger/pilotui> | `../../lib-vue-components` |
+
+### Working across siblings
+
+When a dashboard task depends on, or breaks, a sibling — e.g. a backend RPC the extension also calls, or a `pilotui` component that needs a fix before the dashboard can consume it — pull the sibling in locally so you can build and test the dashboard branch against it:
+
+1. **Search locally first.** The siblings are usually already cloned next to this repo (see *Typical local path* above — the extension is a direct sibling; `pilotui` is checked out as `lib-vue-components`, whose `package.json` name is `pilotui`). Check those paths before cloning.
+2. **Clone (download) it if missing.** `git clone <GitHub URL>` into a sibling directory, then `yarn install`.
+3. **Branch the sibling — never mutate its main line.** To exercise the cross-repo change, create a feature branch on the sibling using the same `CU-<taskId>_…` convention as [Branching](#branching), make your edits there, and run it locally (`yarn dev` / `yarn build`; for `pilotui`, build and `yarn link` it into `frontend/`). This lets you verify the dashboard's main branch work against the live sibling. **Keep dashboard-driven, experimental changes on the sibling's feature branch** — don't commit them onto the sibling's `dev`/`main`; only land them through that sibling's own PR flow if they're genuinely intended.
+
 ## Repo layout
 
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ subturtle-dashboard-app/
 └── Dockerfile         # Docker configuration
 ```
 
+## 🔗 Sibling Repositories
+
+SubTurtle is split across several repositories. These siblings interact with the dashboard and may need to be cloned (or branched) locally to develop and test a cross-repo change end to end:
+
+| Repo          | Purpose                                                                                              | Repository                                                                              |
+| ------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **Extension** | Browser extension — the learn-by-subtitle capture surface. Shares the same `@modular-rest` backend. | [codebridger/subturtle-extension-apps](https://github.com/codebridger/subturtle-extension-apps) |
+| **PilotUI**   | In-house Vue 3 + Tailwind component library (`pilotui`) consumed by the frontend.                    | [codebridger/pilotui](https://github.com/codebridger/pilotui)                           |
+
+To work across repositories, clone the sibling next to this one (or reuse an existing local clone), create a feature branch on the sibling for any experimental change, run it locally, and point your dashboard branch at it. Keep dashboard-driven experiments on the sibling's feature branch — don't commit them to the sibling's `dev`/`main`.
+
 ## 🚀 Technology Stack
 
 ### Frontend


### PR DESCRIPTION
## 📋 Summary
This PR adds documentation for sibling repositories (extension, pilotui) and outlines the cross-repo testing workflow.

## 🔗 Related Tasks
[#0c5c003](https://app.clickup.com/t/0c5c003) - Add sibling repos and cross-repo testing workflow documentation

## 📝 Additional Details
The updates help clarify how related repositories interact and how to run tests that span across these repos, improving developer onboarding and maintenance.

## 📜 Commit List
[0c5c003](https://app.clickup.com/t/0c5c003) docs: add sibling repos (extension, pilotui) and cross-repo testing workflow